### PR TITLE
Added support for openbsd.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,9 @@
 
-SUBDIRS = include src tools tests examples doc
+SUBDIRS = include src tools tests doc
+
+if ENABLE_EXAMPLES
+SUBDIRS += examples
+endif
 
 EXTRA_DIST = README.md
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,13 @@
-
-AC_INIT([noise-c], [0.0.1])
+AC_INIT([noise-c],[0.0.1])
 AM_INIT_AUTOMAKE
 AC_CONFIG_MACRO_DIR([m4])
 
 AM_PROG_AS
 
 AC_PROG_CC
+AM_PROG_CC_C_O
 AC_PROG_CC_STDC
+
 AC_PROG_RANLIB
 AC_PROG_LEX
 AC_PROG_YACC
@@ -64,11 +65,6 @@ tests/performance/Makefile
 tools/Makefile
 tools/keytool/Makefile
 tools/protoc/Makefile
-examples/Makefile
-examples/echo/Makefile
-examples/echo/echo-client/Makefile
-examples/echo/echo-keygen/Makefile
-examples/echo/echo-server/Makefile
 doc/Makefile])
 
 AC_ARG_WITH([libsodium],
@@ -81,7 +77,6 @@ AC_ARG_WITH([openssl],
     [use openssl for crypto @<:@default=check@:>@])],
   [],
   [with_openssl=no])
-
 PKG_PROG_PKG_CONFIG
 AS_IF([test -n "$PKG_CONFIG"], [
   AS_CASE(["$with_libsodium"],
@@ -101,16 +96,25 @@ AS_IF([test -n "$PKG_CONFIG"], [
   AM_CONDITIONAL([USE_OPENSSL],[false])
 ])
 
-AC_ARG_ENABLE(asan, AC_HELP_STRING([--enable-asan],
-			[Compile with Address Sanitizer]), [
+AC_ARG_ENABLE(examples, AS_HELP_STRING([--enable-examples],[Compile with examples]), [
+    if (test "${enableval}" = "yes"); then
+		AC_CONFIG_FILES([examples/Makefile
+			examples/echo/Makefile
+			examples/echo/echo-client/Makefile
+			examples/echo/echo-keygen/Makefile
+			examples/echo/echo-server/Makefile
+		])
+	fi
+])
+
+AC_ARG_ENABLE(asan, AS_HELP_STRING([--enable-asan],[Compile with Address Sanitizer]), [
 	if (test "${enableval}" = "yes"); then
 		CFLAGS="$CFLAGS -fsanitize=address";
 		LDFLAGS="$LDFLAGS -fsanitize=address"
 	fi
 ])
 
-AC_ARG_ENABLE(ubsan, AC_HELP_STRING([--enable-ubsan],
-			[Compile with Undefined Behavior Sanitizer]), [
+AC_ARG_ENABLE(ubsan, AS_HELP_STRING([--enable-ubsan],[Compile with Undefined Behavior Sanitizer]), [
 	if (test "${enableval}" = "yes"); then
 		CFLAGS="$CFLAGS -fsanitize=undefined";
 		LDFLAGS="$LDFLAGS -fsanitize=undefined"
@@ -118,3 +122,8 @@ AC_ARG_ENABLE(ubsan, AC_HELP_STRING([--enable-ubsan],
 ])
 
 AC_OUTPUT
+m4_unquote(
+  _m4_defn([_m4_wrap_text])_m4_popdef([_m4_wrap_text]))m4_unquote(
+  _m4_defn([_m4_wrap_text])_m4_popdef([_m4_wrap_text]))
+m4_unquote(
+  _m4_defn([_m4_wrap_text])_m4_popdef([_m4_wrap_text]))

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_PROG_AS
 
 AC_PROG_CC
+AS_CASE([$host_os],
+[openbsd*], [AM_PROG_CC_C_O],
+[*],
+[])
+
 AC_PROG_CC_STDC
 AC_PROG_RANLIB
 AC_PROG_LEX

--- a/configure.ac
+++ b/configure.ac
@@ -5,9 +5,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_PROG_AS
 
 AC_PROG_CC
-AM_PROG_CC_C_O
 AC_PROG_CC_STDC
-
 AC_PROG_RANLIB
 AC_PROG_LEX
 AC_PROG_YACC
@@ -96,16 +94,19 @@ AS_IF([test -n "$PKG_CONFIG"], [
   AM_CONDITIONAL([USE_OPENSSL],[false])
 ])
 
-AC_ARG_ENABLE(examples, AS_HELP_STRING([--enable-examples],[Compile with examples]), [
-    if (test "${enableval}" = "yes"); then
-		AC_CONFIG_FILES([examples/Makefile
-			examples/echo/Makefile
-			examples/echo/echo-client/Makefile
-			examples/echo/echo-keygen/Makefile
-			examples/echo/echo-server/Makefile
-		])
-	fi
-])
+AC_ARG_ENABLE([examples],
+  AS_HELP_STRING([--enable-examples],[Compile with examples]),
+  [enable_examples=$enableval],
+  [enable_examples=no])
+
+AS_IF([test "$enable_examples" = "yes"],
+  [AC_CONFIG_FILES([
+      examples/Makefile
+      examples/echo/Makefile
+      examples/echo/echo-client/Makefile
+      examples/echo/echo-keygen/Makefile
+      examples/echo/echo-server/Makefile
+])])
 
 AC_ARG_ENABLE(asan, AS_HELP_STRING([--enable-asan],[Compile with Address Sanitizer]), [
 	if (test "${enableval}" = "yes"); then

--- a/configure.ac
+++ b/configure.ac
@@ -104,8 +104,9 @@ AC_ARG_ENABLE([examples],
   [enable_examples=$enableval],
   [enable_examples=no])
 
-AS_IF([test "$enable_examples" = "yes"],
-  [AC_CONFIG_FILES([
+AC_ARG_ENABLE([examples], AS_HELP_STRING([--enable-examples],[Compile with examples]), [
+  AM_CONDITIONAL([ENABLE_EXAMPLES], [test "${enableval}" = "yes"]),
+  AC_CONFIG_FILES([
       examples/Makefile
       examples/echo/Makefile
       examples/echo/echo-client/Makefile

--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -27,6 +27,9 @@ ED25519_CPPFLAGS = -DED25519_CUSTOMHASH -DED25519_CUSTOMRANDOM
 AM_CPPFLAGS += $(ED25519_CPPFLAGS)
 endif
 
+.s.o:
+	$(CC) $(CFLAGS) -c $< -o $@
+
 libnoiseprotocol_a_SOURCES = \
 	cipherstate.c \
 	dhstate.c \

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -23,10 +23,18 @@
 #ifndef NOISE_INTERNAL_H
 #define NOISE_INTERNAL_H
 
+#if defined(linux) || defined(__linux) || defined(__linux__)
+#define __LINUX__
+#elif defined(__WIN32__) || defined(WIN32)
+#define __WIN__
+#elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD)
+#define __BSD__
+#endif
+
 #include <noise/protocol.h>
-#if defined(__WIN32__) || defined(WIN32)
+#if defined(__WIN__)
 #include <malloc.h>
-#elif defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(__BSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -26,6 +26,8 @@
 #include <noise/protocol.h>
 #if defined(__WIN32__) || defined(WIN32)
 #include <malloc.h>
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif

--- a/src/protocol/rand_os.c
+++ b/src/protocol/rand_os.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN32__)
+#if defined(__WIN__) || defined(__CYGWIN32__)
 #include <windows.h>
 #include <wincrypt.h>
 #else
@@ -48,10 +48,10 @@
  * This module will require modification when porting to new systems.
  */
 
-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__APPLE__)
+#if defined(__LINUX__) || defined(__BSD__) || defined(__APPLE__)
 #define RANDOM_DEVICE   "/dev/urandom"
 #endif
-#if defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN32__)
+#if defined(__WIN__) || defined(__CYGWIN32__)
 #define RANDOM_WIN32    1
 #endif
 


### PR DESCRIPTION
I don't know the details about make on openbsd, but I noticed make transmits an incorrect output directory for mlkemxxxx_amd64_avx2.o to compiler.
Solution: `.s.o:
	$(CC) $(CFLAGS) -c $< -o $@
`
Also, alloc.h don't exist on OpenBSD, so I added stdlib.h.
